### PR TITLE
feat: support for template directories

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rose-pine/build",
-	"version": "0.8.2",
+	"version": "0.9.0",
 	"description": "Theme generator for Rosé Pine",
 	"license": "MIT",
 	"repository": "rose-pine/build",

--- a/source/utils/generate-variants.ts
+++ b/source/utils/generate-variants.ts
@@ -9,53 +9,85 @@ import {
 import { type Config } from "../config.js";
 import { formatColor } from "./format-color.js";
 
+function generateVariant(
+	variant: (typeof variants)[keyof typeof variants],
+	template: string,
+	filename: string,
+	config: Config,
+) {
+	const description =
+		"All natural pine, faux fur and a bit of soho vibes for the classy minimalist";
+	const type = variant.name === "dawn" ? "light" : "dark";
+
+	let result = template;
+
+	for (const role of roleKeys) {
+		const currentColor = roleColors[role][variant.key as keyof typeof variants];
+
+		if ("alpha" in currentColor) {
+			// Replace alpha colors
+			result = result.replaceAll(
+				`${config.prefix}${role}Alpha`,
+				formatColor(currentColor.alpha, config.format, config.stripSpaces),
+			);
+		}
+
+		// Replace colors
+		result = result.replaceAll(
+			`${config.prefix}${role}`,
+			formatColor(currentColor, config.format, config.stripSpaces),
+		);
+	}
+
+	// Replace built-in values
+	result = result.replaceAll(`${config.prefix}id`, variant.id);
+	result = result.replaceAll(`${config.prefix}name`, variant.name);
+	result = result.replaceAll(`${config.prefix}description`, description);
+	result = result.replaceAll(`${config.prefix}type`, type);
+
+	// Replace custom values
+	result = result.replaceAll(
+		/\$\((.*?)\|(.*?)\|(.*?)\)/gm,
+		`$${variantKeys.indexOf(variant.key as keyof typeof variants) + 1}`,
+	);
+
+	fs.mkdirSync(config.output, { recursive: true });
+	fs.writeFileSync(path.join(config.output, filename), result, "utf8");
+}
+
 export const generateVariants = (config: Config) => {
-	const template = fs.readFileSync(config.template, "utf8").toString();
+	const isDir = fs.lstatSync(config.template).isDirectory();
 	const extension = path.extname(config.template);
 
 	for (const variant of variantKeys) {
 		const currentVariant = variants[variant];
-		const description =
-			"All natural pine, faux fur and a bit of soho vibes for the classy minimalist";
-		const type = variant === "dawn" ? "light" : "dark";
 
-		let result = template;
+		if (isDir) {
+			fs.mkdirSync(path.join(config.output, currentVariant.key), {
+				recursive: true,
+			});
 
-		for (const role of roleKeys) {
-			const currentColor = roleColors[role][variant];
+			const templateFiles = fs.readdirSync(config.template);
+			for (const file of templateFiles) {
+				const template = fs.readFileSync(
+					path.join(config.template, file),
+					"utf8",
+				);
 
-			if ("alpha" in currentColor) {
-				// Replace alpha colors
-				result = result.replaceAll(
-					`${config.prefix}${role}Alpha`,
-					formatColor(currentColor.alpha, config.format, config.stripSpaces),
+				generateVariant(
+					currentVariant,
+					template,
+					path.join(currentVariant.key, file),
+					config,
 				);
 			}
-
-			// Replace colors
-			result = result.replaceAll(
-				`${config.prefix}${role}`,
-				formatColor(currentColor, config.format, config.stripSpaces),
+		} else {
+			generateVariant(
+				currentVariant,
+				fs.readFileSync(config.template, "utf8").toString(),
+				currentVariant.id + extension,
+				config,
 			);
 		}
-
-		// Replace built-in values
-		result = result.replaceAll(`${config.prefix}id`, currentVariant.id);
-		result = result.replaceAll(`${config.prefix}name`, currentVariant.name);
-		result = result.replaceAll(`${config.prefix}description`, description);
-		result = result.replaceAll(`${config.prefix}type`, type);
-
-		// Replace custom values
-		result = result.replaceAll(
-			/\$\((.*?)\|(.*?)\|(.*?)\)/gm,
-			`$${variantKeys.indexOf(variant) + 1}`,
-		);
-
-		fs.mkdirSync(config.output, { recursive: true });
-		fs.writeFileSync(
-			`${config.output}/${currentVariant.id}${extension}`,
-			result,
-			"utf8",
-		);
 	}
 };

--- a/source/utils/generate-variants.ts
+++ b/source/utils/generate-variants.ts
@@ -17,7 +17,7 @@ function generateVariant(
 ) {
 	const description =
 		"All natural pine, faux fur and a bit of soho vibes for the classy minimalist";
-	const type = variant.name === "dawn" ? "light" : "dark";
+	const type = variant.key === "dawn" ? "light" : "dark";
 
 	let result = template;
 

--- a/test/main.js
+++ b/test/main.js
@@ -36,6 +36,7 @@ test("json template with hex values", async (t) => {
 		name: "Rosé Pine",
 		description:
 			"All natural pine, faux fur and a bit of soho vibes for the classy minimalist",
+		type: "dark",
 		colors: {
 			base: `#${variantColors.main.base.hex}`,
 			surface: `#${variantColors.main.surface.hex}`,
@@ -62,6 +63,7 @@ test("json template with hex values", async (t) => {
 		name: "Rosé Pine Moon",
 		description:
 			"All natural pine, faux fur and a bit of soho vibes for the classy minimalist",
+		type: "dark",
 		colors: {
 			base: `#${variantColors.moon.base.hex}`,
 			surface: `#${variantColors.moon.surface.hex}`,
@@ -88,6 +90,7 @@ test("json template with hex values", async (t) => {
 		name: "Rosé Pine Dawn",
 		description:
 			"All natural pine, faux fur and a bit of soho vibes for the classy minimalist",
+		type: "light",
 		colors: {
 			base: `#${variantColors.dawn.base.hex}`,
 			surface: `#${variantColors.dawn.surface.hex}`,
@@ -146,6 +149,7 @@ test("template directory with multiple files", async (t) => {
 			name: "Rosé Pine" + (variant !== "main" ? ` ${capitalizedVariant}` : ""),
 			description:
 				"All natural pine, faux fur and a bit of soho vibes for the classy minimalist",
+			type: variant === "dawn" ? "light" : "dark",
 		});
 
 		switch (variant) {

--- a/test/main.js
+++ b/test/main.js
@@ -125,3 +125,39 @@ test("txt template with variant-unique values", async (t) => {
 	t.is(moon, "Rosé Pine Moon is our not as dark variant");
 	t.is(dawn, "Rosé Pine Dawn is our light variant");
 });
+
+test("template directory with multiple files", async (t) => {
+	await build({
+		__skipReadmeVersion: true,
+		template: mockDir + "/template",
+		output: mockDir + "/dist",
+	});
+
+	["main", "moon", "dawn"].forEach((variant) => {
+		const [json, txt] = ["json", "txt"].map((ext) =>
+			readFile(`${variant}/template.${ext}`).trim(),
+		);
+
+		const capitalizedVariant =
+			variant.charAt(0).toUpperCase() + variant.slice(1);
+
+		t.like(JSON.parse(json), {
+			id: `rose-pine${variant !== "main" ? `-${variant}` : ""}`,
+			name: "Rosé Pine" + (variant !== "main" ? ` ${capitalizedVariant}` : ""),
+			description:
+				"All natural pine, faux fur and a bit of soho vibes for the classy minimalist",
+		});
+
+		switch (variant) {
+			case "main":
+				t.is(txt, "Rosé Pine is our dark variant");
+				break;
+			case "moon":
+				t.is(txt, "Rosé Pine Moon is our not as dark variant");
+				break;
+			case "dawn":
+				t.is(txt, "Rosé Pine Dawn is our light variant");
+				break;
+		}
+	});
+});

--- a/test/mock/template/template.json
+++ b/test/mock/template/template.json
@@ -1,0 +1,25 @@
+{
+	"id": "$id",
+	"name": "$name",
+	"description": "$description",
+	"type": "$type",
+	"colors": {
+		"base": "$base",
+		"surface": "$surface",
+		"overlay": "$overlay",
+		"muted": "$muted",
+		"subtle": "$subtle",
+		"love": "$love",
+		"gold": "$gold",
+		"rose": "$rose",
+		"pine": "$pine",
+		"foam": "$foam",
+		"iris": "$iris",
+		"highlightLow": "$highlightLow",
+		"highlightLowAlpha": "$highlightLowAlpha",
+		"highlightMed": "$highlightMed",
+		"highlightMedAlpha": "$highlightMedAlpha",
+		"highlightHigh": "$highlightHigh",
+		"highlightHighAlpha": "$highlightHighAlpha"
+	}
+}

--- a/test/mock/template/template.txt
+++ b/test/mock/template/template.txt
@@ -1,0 +1,1 @@
+$name is our $(dark variant|not as dark variant|light variant)


### PR DESCRIPTION
I'm not sure if this is something you're interested in, but i ran into this problem a few times so i though it would be easier to add support for template directories instead of writing a shell script for this every time. 

I wasn't quite sure how to do naming for the output directories, for now i just used the variant name.
Let me know if there are any changes that I need to make