### PR TITLE
feat: -f rgb-ansi

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -45,6 +45,7 @@ $ npx @rose-pine/build --help
 | hex-ns       | `ebbcba`             |
 | rgb          | `235, 188, 186`      |
 | rgb-ns       | `235 188 186`        |
+| rgb-ansi     | `235;188;186`        |
 | rgb-array    | `[235, 188, 186]`    |
 | rgb-function | `rgb(235, 188, 186)` |
 | hsl          | `2, 55%, 83%`        |

--- a/source/config.ts
+++ b/source/config.ts
@@ -19,6 +19,7 @@ export type Config = {
 		| "hex-ns"
 		| "rgb"
 		| "rgb-ns"
+		| "rgb-ansi"
 		| "rgb-array"
 		| "rgb-function"
 		| "hsl"

--- a/source/utils/format-color.ts
+++ b/source/utils/format-color.ts
@@ -12,11 +12,17 @@ export const formatColor = (
 	const formattedRgb = rgb.join(", ");
 	const formattedHsl = `${h!}, ${s!}%, ${l!}%${hsl[3] ? `, ${hsl[3]}` : ""}`;
 
+	//ansi true-color strings cannot have spaces
+	if ( format == 'rgb-ansi' ) { 
+		stripSpaces = true
+	}
+
 	const formats = {
 		hex: `#${hex}`,
 		"hex-ns": hex,
 		rgb: formattedRgb,
 		"rgb-ns": formattedRgb.replaceAll(",", ""),
+		"rgb-ansi": formattedRgb.replaceAll(",", ";"),
 		"rgb-array": `[${formattedRgb}]`,
 		"rgb-function": `rgb${rgb[3] ? "a" : ""}(${formattedRgb})`,
 		hsl: formattedHsl,

--- a/test/format-color.js
+++ b/test/format-color.js
@@ -14,10 +14,12 @@ test("color formats", (t) => {
 	t.is(formatColor(testColor, "hex-ns", true), "ebbcba");
 	t.is(formatColor(testColor, "rgb"), "235, 188, 186");
 	t.is(formatColor(testColor, "rgb-ns"), "235 188 186");
+	t.is(formatColor(testColor, "rgb-ansi"), "235;188;186");
 	t.is(formatColor(testColor, "rgb-array"), "[235, 188, 186]");
 	t.is(formatColor(testColor, "rgb-function"), "rgb(235, 188, 186)");
 	t.is(formatColor(testColor, "rgb", true), "235,188,186");
 	t.is(formatColor(testColor, "rgb-ns", true), "235188186");
+	t.is(formatColor(testColor, "rgb-ansi", true), "235;188;186");
 	t.is(formatColor(testColor, "rgb-array", true), "[235,188,186]");
 	t.is(formatColor(testColor, "rgb-function", true), "rgb(235,188,186)");
 	t.is(formatColor(testColor, "hsl"), "2, 55%, 83%");
@@ -43,10 +45,12 @@ test("alpha color formats", (t) => {
 	t.is(formatColor(testColor, "hex-ns", true), "6e6a8614");
 	t.is(formatColor(testColor, "rgb"), "110, 106, 134, 0.08");
 	t.is(formatColor(testColor, "rgb-ns"), "110 106 134 0.08");
+	t.is(formatColor(testColor, "rgb-ansi"), "110;106;134;0.08");
 	t.is(formatColor(testColor, "rgb-array"), "[110, 106, 134, 0.08]");
 	t.is(formatColor(testColor, "rgb-function"), "rgba(110, 106, 134, 0.08)");
 	t.is(formatColor(testColor, "rgb", true), "110,106,134,0.08");
 	t.is(formatColor(testColor, "rgb-ns", true), "1101061340.08");
+	t.is(formatColor(testColor, "rgb-ansi", true), "110;106;134;0.08");
 	t.is(formatColor(testColor, "rgb-array", true), "[110,106,134,0.08]");
 	t.is(formatColor(testColor, "rgb-function", true), "rgba(110,106,134,0.08)");
 	t.is(formatColor(testColor, "hsl"), "249, 12%, 47%, 0.08");


### PR DESCRIPTION
Hello! `-f rgb-ansi` seems ready!

✓ readme
✓ source 
✓ test

✓ const-void/rose-pine-zsh - generates rose-pine themes for `prompt=` etc :) 

```zsh
# cp
$ git clone https://github.com/const-void/rose-pine-zsh.git

# bld from template
$ cd path/to/rose-pine/build/dist
$ node cli.js -f rgb-ansi -t ~/path/to/rose-pine-zsh/src/template.zsh -o ~/path/to/rose-pine-zsh/dist/themes

# tst
$ cd ~/path/to/rose-pine-zsh/
$ make test
```

ty again.