### PR TITLE
Mark all `.ts` files as TypeScript

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Let GitHub know that *all* .ts files are TypeScript
+*.ts linguist-language=TypeScript


### PR DESCRIPTION
I noticed that `source/cli.ts` is currently detected as JavaScript on GitHub (this happens because of the `#!/usr/bin/env node` shebang). This lets GitHub know that `cli.ts` is TypeScript, updating language distribution stats and syntax highlighting on the web.

***

BTW, one workaround besides doing this is to have a project structure kind of like this:

```javascript
#!/usr/bin/env node
// bin/cli.js
// thin JS wrapper
import cli from "../dist/cli.js";
cli();
```

```typescript
// source/cli.ts
export default function implementation() {}
```

This keeps the `node` shebang outside of files that node can't run.