### PR TITLE
fix: Check for template file and output dir

### DIFF
--- a/source/utils/generate-variants.ts
+++ b/source/utils/generate-variants.ts
@@ -56,7 +56,11 @@ function generateVariant(
 }
 
 export const generateVariants = (config: Config) => {
-	const isDir = fs.lstatSync(config.template).isDirectory();
+	if (!fs.existsSync(config.template)) {
+		console.error("🔍 Specified template does not exist:", config.template);
+		return;
+	}
+	const isDir = fs.existsSync(config.output) && fs.lstatSync(config.output).isDirectory();
 	const extension = path.extname(config.template);
 
 	for (const variant of variantKeys) {


### PR DESCRIPTION
- Current logic checks if the template is a dir, should be checking output. It will also throw an exception since `lstatSync` does not handle missing files
- Add check to make sure template exists, give an error message instead of ENOENT
- Add check for output dir so exception is not thrown